### PR TITLE
SHOT-3556: Playlist and Version Experience for VRED Review

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,30 +30,32 @@ class ReviewWithVRED(Application):
         """
 
         try:
-            if self.execute_hook("hook_verify_install"):
-                # Make sure we check on the permissions and platforms settings
-                deny_permissions = self.get_setting("deny_permissions")
-                deny_platforms = self.get_setting("deny_platforms")
-                params = {
-                    "title": "Review with VRED",
-                    "deny_permissions": deny_permissions,
-                    "deny_platforms": deny_platforms,
-                    "supports_multiple_selection": False,
-                }
-
-                # Now register the command with the engine
-                self.engine.register_command(
-                    "Review with VRED", self._launch_via_hook, params
-                )
-
-            else:
-                # Bring up the Help UI
-                app_payload = self.import_module("app")
-                menu_callback = lambda: app_payload.dialog.show_dialog(self)
-                self.engine.register_command("Review with VRED", menu_callback)
-
+            installed = self.execute_hook("hook_verify_install")
         except TankError as error:
+            # Log an error message and return immediately on failure to find VRED installation.
             self.log_error("Failed to check VRED installation: {}".format(error))
+            return
+
+        if installed:
+            # Make sure we check on the permissions and platforms settings
+            deny_permissions = self.get_setting("deny_permissions")
+            deny_platforms = self.get_setting("deny_platforms")
+            params = {
+                "title": "Review with VRED",
+                "deny_permissions": deny_permissions,
+                "deny_platforms": deny_platforms,
+                "supports_multiple_selection": False,
+            }
+
+            # Now register the command with the engine
+            self.engine.register_command(
+                "Review with VRED", self._launch_via_hook, params
+            )
+        else:
+            # No installatino found, bring up the Help UI
+            app_payload = self.import_module("app")
+            menu_callback = lambda: app_payload.dialog.show_dialog(self)
+            self.engine.register_command("Review with VRED", menu_callback)
 
     def _launch_via_hook(self, entity_type, entity_ids):
         """

--- a/app.py
+++ b/app.py
@@ -73,9 +73,7 @@ class ReviewWithVRED(Application):
                       from to load first.
 
         :param entity_type: The type of the entities.
-        :type entity_type: str
         :param entity_ids: The list of ids of the entities
-        :type entity_type: list
         """
 
         if not entity_ids:
@@ -90,20 +88,20 @@ class ReviewWithVRED(Application):
 
         if published_file is None:
             # Published file for entity was not found
-            raise Exception(
+            raise TankError(
                 "Sorry, this can only be used on an entity with an associated published file."
             )
 
         if published_file.get("error", None) is not None:
             # There was an error getting the published file from the entity
-            raise Exception(published_file["error"])
+            raise TankError(published_file["error"])
 
         # Extract the path on local disk for the published file that will be openedin VRED
         # for review
         path_on_disk = _get_published_file_path(published_file)
 
         if path_on_disk is None:
-            raise Exception(
+            raise TankError(
                 "Unable to determine the path on disk for published file with id '{}'.".format(
                     published_file["id"]
                 )
@@ -112,7 +110,7 @@ class ReviewWithVRED(Application):
         # Only check the path on disk if there is one. The user is allowed launch VRED with no
         # initial file path.
         if path_on_disk and not os.path.exists(path_on_disk):
-            raise Exception(
+            raise TankError(
                 "The file associated with this publish '{}' cannot be found on disk!".format(
                     path_on_disk
                 )
@@ -128,7 +126,9 @@ class ReviewWithVRED(Application):
 
         except TankError as error:
             self.log_error(
-                "Failed to launch VRED for this published file: {}".format(error)
+                "An error occurred when attempting to launch VRED for this published file: {}".format(
+                    error
+                )
             )
 
     def _get_published_file_from_entity(self, entity_type, entity_id):
@@ -139,6 +139,9 @@ class ReviewWithVRED(Application):
         published entity type: The object for `entity_type` and `entity_id` will be returned.
         "Version": The last created published file will be returned
         "Playlist": No published file object will be returned
+
+        :param entity_type: The entity type
+        :param entity_id: The entity id
         """
 
         published_file = None
@@ -202,6 +205,8 @@ class ReviewWithVRED(Application):
 def _get_published_file_path(published_file):
     """
     Return the path on disk for the given published file.
+
+    :param published_file: The PublishedFile entity
     """
 
     if published_file is None:

--- a/app.py
+++ b/app.py
@@ -32,7 +32,7 @@ class ReviewWithVRED(Application):
         try:
             installed = self.execute_hook("hook_verify_install")
         except TankError as error:
-            # Log an error message and return immediately on failure to find VRED installation.
+            # Log an error and return immediately on failure to find VRED installation.
             self.log_error("Failed to check VRED installation: {}".format(error))
             return
 
@@ -72,12 +72,18 @@ class ReviewWithVRED(Application):
                       loaded for review, the user will be shown the Version list to select
                       from to load first.
 
-        :param entity_type: The entity's type.
-        :param entity_id: The id of the entity.
+        :param entity_type: The type of the entities.
+        :type entity_type: str
+        :param entity_ids: The list of ids of the entities
+        :type entity_type: list
         """
 
-        if entity_ids and len(entity_ids) != 1:
-            raise Exception("Action only accepts a single item.")
+        if not entity_ids:
+            self.log_warning("No entity was passed - returning immediately.")
+            return
+
+        if len(entity_ids) > 1:
+            raise TankError("Action only accepts a single item.")
 
         entity_id = entity_ids[0]
         published_file = self._get_published_file_from_entity(entity_type, entity_id)

--- a/app.py
+++ b/app.py
@@ -96,7 +96,7 @@ class ReviewWithVRED(Application):
             # There was an error getting the published file from the entity
             raise TankError(published_file["error"])
 
-        # Extract the path on local disk for the published file that will be openedin VRED
+        # Extract the path on local disk for the published file that will be opened in VRED
         # for review
         path_on_disk = _get_published_file_path(published_file)
 

--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ class ReviewWithVRED(Application):
 
     def init_app(self):
         """
-        Called as the application is being initialized
+        Called as the application is being initialized.
         """
 
         try:
@@ -57,7 +57,21 @@ class ReviewWithVRED(Application):
 
     def _launch_via_hook(self, entity_type, entity_ids):
         """
-        Executes the "hook_launch_publish" hook.
+        Executes the "hook_launch_publish" hook, passing a context and file path params
+        that are extracted from process the entity passed in. This method only supports
+        entity typess: PublishedFile entity type, Version and Playlist. For each entity
+        type, the context passed to the hook will be the entity passed in to this method.
+        The file path will be determined based on the entity type:
+            PublishedFile entity types: file path will be the PublishedFile's path itself
+            Version: file path will be the latest PublishedFile whose PublishedFileType
+                     is in the accepted list. The "latest" PublishedFile is determined by
+                     the PublishedFile with the highest version.
+            Playlist: file path will be empty (""). For now, no Version is autoamatically
+                      loaded for review, the user will be shown the Version list to select
+                      from to load first.
+
+        :param entity_type: The entity's type.
+        :param entity_id: The id of the entity.
         """
 
         if entity_ids and len(entity_ids) != 1:
@@ -153,9 +167,8 @@ class ReviewWithVRED(Application):
                 }
 
             elif len(published_files) != 1:
-                # FIXME error message
                 published_file = {
-                    "error": "Failed to load Version for review with VRED because there is more than one PublishedFile entity with the same PublishedFileType associated for this Version"
+                    "error": "Failed to load Version for review with VRED because there is more than one PublishedFile entity with the same PublishedFileType associated for this Version."
                 }
 
             else:

--- a/info.yml
+++ b/info.yml
@@ -33,7 +33,7 @@ configuration:
   accepted_published_file_types:
     type: list
     values: { type: str }
-    default_value: [ VRED Scene ]
+    default_value: [ VRED Scene, Alias File, Catpart File, Jt File, Igs File ]
     description: "A list of PublishedFileTypes that are allowed for review with VRED."
 
   hook_launch_publish:

--- a/info.yml
+++ b/info.yml
@@ -30,11 +30,6 @@ configuration:
                      If you don't want it to appear on the Shotgun Pipeline Toolkit action menu
                      for a platform, just include it in the the deny_platforms list. Valid values
                      are Windows, Mac and Linux."
-  accepted_published_file_types:
-    type: list
-    values: { type: str }
-    default_value: [ VRED Scene, Alias File, Catpart File, Jt File, Igs File ]
-    description: "A list of PublishedFileTypes that are allowed for review with VRED."
 
   hook_launch_publish:
     type: hook

--- a/info.yml
+++ b/info.yml
@@ -30,13 +30,11 @@ configuration:
                      If you don't want it to appear on the Shotgun Pipeline Toolkit action menu
                      for a platform, just include it in the the deny_platforms list. Valid values
                      are Windows, Mac and Linux."
-
-  viewer_extensions:
+  accepted_published_file_types:
     type: list
     values: { type: str }
-    default_value: [ vpb ]
-    description: "A list of file extensions to send to the viewer application.
-                       Do not include the period character. Example: `[vpb]`"
+    default_value: [ VRED Scene ]
+    description: "A list of PublishedFileTypes that are allowed for review with VRED."
 
   hook_launch_publish:
     type: hook


### PR DESCRIPTION
* Simplified logic in `init_app` method
* Modified `_launch_via_hook` method to load in a Version or Playlist context in SG Panel when launching VRED for review
* Renamed config value from `viewer_extensions` to `accepted_published_file_types` and now specifies the PublishedFileType name instead of the file extension to allow easier filtering at the API level

@rob-aitchison I originally wanted to move the config option `accepted_published_file_types` to tk-vred config instead of this app, since the engine needs this value as well; however, I couldn't get this app to retrieve the config from tk-vred -- it was just empty, but was OK when accessing from tk-vred itself. Can you not access engine config settings from an app?