### PR TITLE
Bugfix SHOT-3644: Review with VRED Toolkit action not showing up

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,8 +31,6 @@ class ReviewWithVRED(Application):
         # Assume we do not have VRED Presenter installed and change if / when
         # we find it.
         installed = False
-        tk = sgtk.sgtk_from_entity("Project", self.context.project["id"])
-        context = tk.context_from_entity("Project", self.context.project["id"])
         try:
             install_check = self.execute_hook("hook_verify_install")
         except TankError as e:


### PR DESCRIPTION
Remove unused variables, which also resolves the bug in SHOT-3644.

In some cases (e.g. starting with a new site that has not pipeline configs and using Advanced Project setup to set up the first project), calling `sgtk.sgtk_from_entity`causes an error because the sgtk instance is not associated with the project we're passing in; resulting in the `Review with VRED` not showing up in SG Toolkit actions