### PR TITLE
SG-43662 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ exclude: "ui\/.*py$"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v6.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -61,6 +61,7 @@ description: "Use VRED Presenter with Flow Production Tracking Panel for reviewi
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.19.5"
+minimum_python_version: "3.9"
 requires_engine_version: "v0.1.0"
 
 # the frameworks required to run this app

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -46,7 +46,7 @@ class AppDialog(QtGui.QWidget):
         return True
 
     def __init__(self, parent=None):
-        super(AppDialog, self).__init__(parent)
+        super().__init__(parent)
         # get the current bundle
         self._app = sgtk.platform.current_bundle()
         self.title = "Review with VRED Help UI"


### PR DESCRIPTION
Set `minimum_python_version` to `3.9` in the app manifest and update old-style `super()` call to Python 3 syntax.